### PR TITLE
Fix example usage to add version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ When creating a workflow which deploys an entire distributed application in one 
 
 ``` yaml
     - name: Deploy Your Service
-      uses: adityakar/workflow-dispatcher
+      uses: adityakar/workflow-dispatcher@v1.0
       with:
         owner: your-github-org
         repo: your-repo


### PR DESCRIPTION
The example doesn't run as-is, since a version number is required.